### PR TITLE
Remove night config depends

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+   - sdk install java 17.0.2-open
+   - sdk use java 17.0.2-open

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,0 @@
-before_install:
-   - sdk install java 17.0.2-open
-   - sdk use java 17.0.2-open

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,8 +33,6 @@
   "depends": {
     "fabricloader": ">=${minFabricVersion}",
     "fabric": ">=${minFabricApiVersion}",
-    "com_electronwill_night-config_core": "*",
-    "com_electronwill_night-config_toml": "*",
     "minecraft": ">=${minMinecraftVersion} <${nextMinecraftVersion}",
     "java": ">=17"
   },


### PR DESCRIPTION
Theses depends aren't needed since night config in already included in the jar and they only cause problems when trying to use the mod in dev environment and running data gen
The only way to solve this is with a depends override which doesn't work very well when you are trying to use CI