### PR TITLE
Port to 1.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
 	id 'java-library'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 
 ext.mcversion = "${minecraftVersion}"
@@ -33,7 +33,7 @@ dependencies {
 
 	modImplementation "net.fabricmc:fabric-loader:${project.fabricVersion}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabricApiVersion}"
-	modImplementation "com.terraformersmc:modmenu:2.0.12"
+	modImplementation "com.terraformersmc:modmenu:1.16.23"
 	implementation 'com.electronwill.night-config:core:3.6.3'
 	implementation 'com.electronwill.night-config:toml:3.6.3'
 
@@ -102,8 +102,6 @@ tasks.withType(JavaCompile).configureEach {
 	// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
 	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
-	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
 }
 
 javadoc {
@@ -144,7 +142,6 @@ publishing {
 		}
 	}
 }
-
 
 curseforge {
 	def changelogName = 'CHANGELOG.md'

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,18 +4,18 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # environment
-minecraftVersion=1.17.1
+minecraftVersion=1.16.5
 projectLoader=Fabric
-fabricVersion=0.11.6
-fabricApiVersion=0.42.1+1.17
+fabricVersion=0.11.3
+fabricApiVersion=0.28.0+1.16
 #puzzlesVersion=v2.0.0-1.17.1-Fabric
 enableHotswap=false
 copyBuildJar=true
 
 # dependencies
-minMinecraftVersion=1.17
+minMinecraftVersion=1.16
 minFabricVersion=0.11.3
-minFabricApiVersion=0.40
+minFabricApiVersion=0.28.0
 #minPuzzlesVersion=2.0.0
 packFormat=7
 
@@ -33,4 +33,4 @@ modGroup=net.minecraftforge
 # publishing
 curseProjectId=547434
 curseReleaseType=release
-curseProjectVersion=1.17, 1.17.1
+curseProjectVersion=1.16, 1.16.1, 1.16.2, 1.16.3, 1.16.4, 1.16.5

--- a/src/main/resources/META-INF/forgeconfigapiport.mixins.json
+++ b/src/main/resources/META-INF/forgeconfigapiport.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "minVersion": "0.8",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_8",
   "package": "net.minecraftforge.mixin",
   "refmap": "META-INF/forgeconfigapiport.refmap.json",
   "mixins": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -38,7 +38,7 @@
     "com_electronwill_night-config_core": "*",
     "com_electronwill_night-config_toml": "*",
     "minecraft": ">=${minMinecraftVersion} <${nextMinecraftVersion}",
-    "java": ">=16"
+    "java": ">=8"
   },
 
   "custom": {


### PR DESCRIPTION
I wanted to use this mod for 1.16 but there seems to be no version/branch for it, so i ported it. This PR is based on the 1.17 version of the mod and is just a bunch of version number changes. No actual source code was changed, just the version numbers in the buildscript. I also loaded the mod in a production environment and it looked like its working. though i have no mods to test it with, but the fabric api version should provide all the necessary features. Sadly i cannot create a pull request for a new branch in this repo, so this will probably just get closed. Thanks in advance.