### PR TITLE
Use % style formatting strings

### DIFF
--- a/src/main/resources/assets/forge/lang/en_us.json
+++ b/src/main/resources/assets/forge/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-  "commands.forge.arguments.enum.invalid": "Enum constant must be one of {0}, found {1}",
+  "commands.forge.arguments.enum.invalid": "Enum constant must be one of %s, found %s",
   "commands.config.getwithtype": "Config for %s of type %s found at %s",
   "commands.config.noconfig": "Config for %s of type %s not found",
 
@@ -20,13 +20,13 @@
   "forge.configgui.entryInvalid": "The value is not valid. Please change it.",
   "forge.configgui.requiresWorldRestartToTakeEffect": "This change requires a world restart to take effect.",
 
-  "forge.configgui.error.boolean.notTrueOrFalse": "The current value is: {0}.\nIt must be true or false.",
+  "forge.configgui.error.boolean.notTrueOrFalse": "The current value is: %s.\nIt must be true or false.",
   "forge.configgui.error.boolean.needsToBeText": "The value must be a text value.",
-  "forge.configgui.error.ranged.notInBounds": "The current value is: {0}.\nIt must be between {1} and {2}.",
-  "forge.configgui.error.ranged.needsToBeOfType": "The value must be of type {0}.",
-  "forge.configgui.error.enum.invalidName": "The current value is: {0}.\nIt must be one of the following:{1}",
+  "forge.configgui.error.ranged.notInBounds": "The current value is: %s.\nIt must be between %s and %s.",
+  "forge.configgui.error.ranged.needsToBeOfType": "The value must be of type %s.",
+  "forge.configgui.error.enum.invalidName": "The current value is: %s.\nIt must be one of the following:%s",
   "forge.configgui.error.enum.needsToBeText": "The value must be a text value.",
-  "forge.configgui.error.permissionHandler.unknownName": "The current value is: {0}.\nIt must be one of the following:{1}",
+  "forge.configgui.error.permissionHandler.unknownName": "The current value is: %s.\nIt must be one of the following:%s",
   "forge.configgui.error.permissionHandler.needsToBeText": "The value must be a text value.",
 
   "forge.configgui.resetToInitial": "Reset to previous value.\n(The value from before opening this screen.)",


### PR DESCRIPTION
{...} style strings are Forge-only, meaning the placeholders are never substituted. Before tooltips would render as the literal ""The current value is: {0}. It must be between {1} and {2}.", they now render as "The current value is: 5724. It must be between 0 and 10.".